### PR TITLE
make datetime aware in friendly_time()

### DIFF
--- a/augur.py
+++ b/augur.py
@@ -4,6 +4,7 @@ from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from datetime import datetime
 from datetime import timedelta
+import pytz
 from flask import Flask, request, redirect, url_for, render_template, flash, make_response, jsonify, send_file
 from flask.ext.sqlalchemy import SQLAlchemy
 import flask.ext.restless
@@ -233,7 +234,8 @@ def friendly_time(dt, past_="ago",
     3 days ago, 5 hours from now etc.
     """
 
-    now = datetime.now()
+    dt = pytz.timezone('US/Eastern').localize(dt)
+    now = datetime.now(pytz.utc)
     if now > dt:
         diff = now - dt
         dt_is_past = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ Flask-Security==1.2.3
 Flask-WTF==0.6
 Jinja2==2.6
 MySQL-python==1.2.3
+pytz==2016.4
 SQLAlchemy==0.7.8
 WTForms==1.0.1
 Werkzeug==0.8.3


### PR DESCRIPTION
Making datetime aware in `friendly_time()` fixed a problem I was having where the recent history was displaying time from the wrong timezone.

Hard-coding 'US/Eastern' into augur.py is a bit unfortunate though...
